### PR TITLE
Align discriminator with generator output and dataset

### DIFF
--- a/TransCGAN_model.py
+++ b/TransCGAN_model.py
@@ -227,14 +227,14 @@ class PatchEmbedding_Linear(nn.Module):
 
 
 class Discriminator(nn.Sequential):
-    def __init__(self, 
-                 in_channels=3,
-                 patch_size=15,
+    def __init__(self,
+                 in_channels=8,
+                 patch_size=1,
                  data_emb_size=50,
-                 label_emb_size=10,
-                 seq_length = 150,
-                 depth=3, 
-                 n_classes=9, 
+                 label_emb_size=32,
+                 seq_length=256,
+                 depth=3,
+                 n_classes=10,
                  **kwargs):
         super().__init__(
             PatchEmbedding_Linear(in_channels, patch_size, data_emb_size, seq_length),


### PR DESCRIPTION
## Summary
- Derive dataset class count and configure generator and discriminator to share consistent channel, length, and class settings.
- Update discriminator defaults to reflect generator output dimensions and label embedding size.
- Add pre-training check ensuring real samples and discriminator input share shape `[batch, channels, 1, seq_len]`.

## Testing
- `python -m py_compile trainCGAN.py TransCGAN_model.py`
- `pip install torch -q` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688ed9ee44688333b477f05d5d4b05be