### PR TITLE
Use dynamic class count for CGAN labels

### DIFF
--- a/cgan_functions.py
+++ b/cgan_functions.py
@@ -96,8 +96,14 @@ def train(args, gen_net: nn.Module, dis_net: nn.Module, gen_optimizer, dis_optim
         real_img_labels = real_img_labels.cuda(args.gpu, non_blocking=True)
 
         # Sample noise as generator input
-        noise = torch.cuda.FloatTensor(np.random.normal(0, 1, (real_imgs.shape[0], args.latent_dim))).cuda(args.gpu, non_blocking=True)
-        fake_img_labels = torch.randint(0, 5, (real_imgs.shape[0],)).cuda(args.gpu, non_blocking=True)
+        noise = torch.cuda.FloatTensor(
+            np.random.normal(0, 1, (real_imgs.shape[0], args.latent_dim))
+        ).cuda(args.gpu, non_blocking=True)
+        fake_img_labels = torch.randint(
+            0,
+            gen_net.module.num_classes if hasattr(gen_net, "module") else gen_net.num_classes,
+            (real_imgs.shape[0],),
+        ).cuda(args.gpu, non_blocking=True)
 
         # ---------------------
         #  Train Discriminator

--- a/trainCGAN.py
+++ b/trainCGAN.py
@@ -4,9 +4,10 @@ from __future__ import print_function
 
 import cfg
 from DataLoader import *
-from TransCGAN_model import * 
+from TransCGAN_model import *
 from cgan_functions import train, save_samples, LinearLrDecay, load_params, copy_params, cur_stages
 from utils import set_log_dir, save_checkpoint, create_logger
+from MotorFFTDataset import MotorFFTDataset
 
 import torch
 import torch.multiprocessing as mp
@@ -93,8 +94,8 @@ def main_worker(gpu, ngpus_per_node, args):
 
     # Determine dataset information
     data_dir = "E:/Downloads/tts-cgan-main/tts-cgan-main/data/processed_fft"
-    num_classes = len({int(f.split("_label_")[-1].split(".")[0])
-                       for f in os.listdir(data_dir) if f.endswith(".npy")})
+    train_set = MotorFFTDataset(data_dir=data_dir)
+    num_classes = train_set.num_classes
 
     # FFT 数据的通道数与频谱长度
     channels = 6
@@ -185,9 +186,6 @@ def main_worker(gpu, ngpus_per_node, args):
     args.max_epoch = args.max_epoch * args.n_critic
     
     #load dataset
-    from MotorFFTDataset import MotorFFTDataset
-
-    train_set = MotorFFTDataset(data_dir=data_dir)
     train_loader = data.DataLoader(
         train_set,
         batch_size=args.batch_size,  # 先用 16


### PR DESCRIPTION
## Summary
- derive MotorFFTDataset labels up front and store class count
- generate fake labels using generator's num_classes instead of hard-coded value
- initialize CGAN networks and dataloader with dataset-reported class count

## Testing
- `python -m py_compile MotorFFTDataset.py cgan_functions.py trainCGAN.py`


------
https://chatgpt.com/codex/tasks/task_e_688ee15fe6ac8333bc57ab74d27ff67d