### PR TITLE
Fix generator output orientation

### DIFF
--- a/TransCGAN_model.py
+++ b/TransCGAN_model.py
@@ -49,11 +49,8 @@ class Generator(nn.Module):
         H, W = 1, self.seq_len
         x = self.blocks(x)
         x = x.reshape(x.shape[0], 1, x.shape[1], x.shape[2])
-        output = self.deconv(x.permute(0, 3, 1, 2))
-        print("z shape:", z.shape)
-        print("label embedding shape:", self.label_embedding(labels).shape)
-        print("concatenated shape:", x.shape)
-        return output 
+        output = self.deconv(x.permute(0, 3, 1, 2)).permute(0, 2, 1, 3)
+        return output
 
 
 class Gen_TransformerEncoderBlock(nn.Sequential):


### PR DESCRIPTION
## Summary
- Ensure generator output matches real image layout by permuting final tensor
- Drop debug prints to reduce training I/O overhead

## Testing
- `python trainCGAN.py --exp_name motor_fft_cgan --max_iter 10000` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*


------
https://chatgpt.com/codex/tasks/task_e_688ee368442c8333a43728c15d28d5d2